### PR TITLE
[GHI#53] Fall Card Animation

### DIFF
--- a/src/application/services/AnimationService.ts
+++ b/src/application/services/AnimationService.ts
@@ -1,8 +1,10 @@
 import type { Card } from "@/domain/entities/Card";
+import type { FallInfo } from "@/domain/entities/GameState";
 
 export const AnimationKeys = {
   GAME_CARDS: "GAME_CARDS",
   PILE_COLLECT: "PILE_COLLECT",
+  FALL: "FALL",
 } as const;
 
 export type AnimationKey = (typeof AnimationKeys)[keyof typeof AnimationKeys];
@@ -10,6 +12,7 @@ export type AnimationKey = (typeof AnimationKeys)[keyof typeof AnimationKeys];
 type Payloads = {
   [AnimationKeys.GAME_CARDS]: Card;
   [AnimationKeys.PILE_COLLECT]: Card;
+  [AnimationKeys.FALL]: FallInfo;
 };
 
 type HandlerMap = {
@@ -18,14 +21,16 @@ type HandlerMap = {
 const listeners: HandlerMap = {
   [AnimationKeys.GAME_CARDS]: new Set(),
   [AnimationKeys.PILE_COLLECT]: new Set(),
+  [AnimationKeys.FALL]: new Set(),
 };
 
 type CorrelatorMap = {
   [K in AnimationKey]: (p: Payloads[K]) => string;
 };
 const correlate: CorrelatorMap = {
-  [AnimationKeys.GAME_CARDS]: (p) => `${p.suit}-${p.rank}`,
-  [AnimationKeys.PILE_COLLECT]: (p) => `${p.suit}-${p.rank}`,
+  [AnimationKeys.GAME_CARDS]: (card) => `${card.suit}-${card.rank}`,
+  [AnimationKeys.PILE_COLLECT]: (card) => `${card.suit}-${card.rank}`,
+  [AnimationKeys.FALL]: ({ card }) => `${card.suit}-${card.rank}`,
 };
 
 type PendingMap = {
@@ -34,6 +39,7 @@ type PendingMap = {
 const pending: PendingMap = {
   [AnimationKeys.GAME_CARDS]: new Map(),
   [AnimationKeys.PILE_COLLECT]: new Map(),
+  [AnimationKeys.FALL]: new Map(),
 };
 
 export const onAnimation = <K extends AnimationKey>(

--- a/src/application/services/GameService.ts
+++ b/src/application/services/GameService.ts
@@ -240,6 +240,7 @@ export function createGameService(
         stateAfterUpdateTableAndHandCards,
         playerId,
         card,
+        analysis.capturePlan.kind !== "none",
       );
 
       const allHandsEmpty = stateAfterFinalizeAfterPlay.players.every(

--- a/src/domain/entities/GameState.ts
+++ b/src/domain/entities/GameState.ts
@@ -77,3 +77,11 @@ export type PlayAnalysis = {
   isFall: boolean;
   isLastRound: boolean;
 };
+
+export type FallKind = "basic" | "ten" | "eleven" | "twelve";
+
+export type FallInfo = {
+  card: Card;
+  kind: FallKind;
+  points: number;
+};

--- a/src/domain/services/moves.test.ts
+++ b/src/domain/services/moves.test.ts
@@ -26,7 +26,12 @@ describe("Moves", () => {
       card,
       analysis.capturePlan,
     );
-    return finalizeAfterPlay(s2, playerId, card);
+    return finalizeAfterPlay(
+      s2,
+      playerId,
+      card,
+      analysis.capturePlan.kind !== "none",
+    );
   };
 
   it("should return state if not current player", () => {

--- a/src/domain/services/moves.ts
+++ b/src/domain/services/moves.ts
@@ -68,7 +68,9 @@ export const analyzePlay = (
   }
 
   const isFall =
-    !!state.lastPlayedCard && state.lastPlayedCard.rank === card.rank;
+    !!state.lastPlayedCard &&
+    state.lastPlayedCard.rank === card.rank &&
+    capturePlan.kind !== "none";
 
   return { ok: true, capturePlan, isFall, isLastRound };
 };
@@ -141,6 +143,7 @@ export const finalizeAfterPlay = (
   state: GameState,
   playerId: string,
   card: Card,
+  wasThereCapture: boolean,
 ): GameState => {
   let nextState = cloneState(state);
   const isLastRound = nextState.deck.length === 0;
@@ -163,7 +166,7 @@ export const finalizeAfterPlay = (
 
   // Fall rule scoring
   const lastCard = state.lastPlayedCard;
-  const isFall = !!lastCard && lastCard.rank === card.rank;
+  const isFall = !!lastCard && lastCard.rank === card.rank && wasThereCapture;
   if (isFall) {
     const pts = fallPoints(card.rank);
     nextState = awardPoints(nextState, playerId, pts);


### PR DESCRIPTION
More animations!

When a player/bot makes a "Fall" it should play a different animation than the previous "play card to table" or "simple capture card" or "cascade card animation"
It should exists 3 types of "Fall" animations

1. Simple pair "Fall" animation: this is for a card rank from 1-7 
2. Better "Fall" animation: this is for card rank 10 and 11
3. Big "Fall" animation: This is only for the card rank 12

And these "Fall" animation should be trigger first or before the other animations that might follow in sequence

Closes #53